### PR TITLE
DWH-2127 keep ru locale

### DIFF
--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -142,7 +142,9 @@ const config = {
 
     // MomentJS loads all the locale, making it a huge JS file.
     // This will ignore the locales from momentJS
-    new MomentLocalesPlugin(),
+    new MomentLocalesPlugin({
+      localesToKeep: ['ru'],
+    }),
 
     new webpack.DefinePlugin({
       'process.env': {


### PR DESCRIPTION
https://jira.hh.ru/browse/DWH-2127

по дефолту MomentLocalesPlugin фильтрует все локали, кроме 'en'

Нам нужна еще одна, ru, тогда datetimepicker календарь будет в привычном формате dd.mm.yyyy + месяцы на ру

https://github.com/iamakulov/moment-locales-webpack-plugin#usage. 
